### PR TITLE
Application acceptance and rejection

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -6,11 +6,16 @@ class Admin::ApplicationsController < ApplicationController
 
   def update
     @application = Application.find(params[:id])
-    if @application.update(application_params)
+    @pet_application = PetApplication.find(params[:id])
+    if @pet_application.update(pet_application_params)
       redirect_to "/admin/applications/#{@application.id}"
     else
       redirect_to "/admin/applications/#{@application.id}"
-      flash[:alert] = "Error: #{error_message(shelter.errors)}"
+      flash[:alert] = "Error: #{error_message(@pet_application.errors)}"
     end
+  end
+
+  def pet_application_params
+    params.permit(:id, :application_id, :pet_id, :status)
   end
 end

--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -8,15 +8,11 @@ class Admin::ApplicationsController < ApplicationController
   def update
     @application = Application.find(params[:id])
     @pet_application = @application.pet_applications.find_by(params[:pet_id])
-    if @pet_application.update(pet_application_params)
+    if @pet_application.update(status: params[:status])
       redirect_to "/admin/applications/#{@application.id}"
     else
       redirect_to "/admin/applications/#{@application.id}"
       flash[:alert] = "Error: #{error_message(@pet_application.errors)}"
     end
-  end
-
-  def pet_application_params
-    params.permit(:id, :application_id, :pet_id, :status)
   end
 end

--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -1,12 +1,13 @@
 class Admin::ApplicationsController < ApplicationController
   def show
     @application = Application.find(params[:id])
+    @pet_applications = PetApplication.by_application_id(@application.id)
     @pets = Pet.search(params[:pet_name]) if params[:pet_name]
   end
 
   def update
     @application = Application.find(params[:id])
-    @pet_application = PetApplication.find(params[:pet_application_id])
+    @pet_application = @application.pet_applications.find_by(params[:pet_id])
     if @pet_application.update(pet_application_params)
       redirect_to "/admin/applications/#{@application.id}"
     else

--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -1,0 +1,16 @@
+class Admin::ApplicationsController < ApplicationController
+  def show
+    @application = Application.find(params[:id])
+    @pets = Pet.search(params[:pet_name]) if params[:pet_name]
+  end
+
+  def update
+    @application = Application.find(params[:id])
+    if @application.update(application_params)
+      redirect_to "/admin/applications/#{@application.id}"
+    else
+      redirect_to "/admin/applications/#{@application.id}"
+      flash[:alert] = "Error: #{error_message(shelter.errors)}"
+    end
+  end
+end

--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -6,7 +6,7 @@ class Admin::ApplicationsController < ApplicationController
 
   def update
     @application = Application.find(params[:id])
-    @pet_application = PetApplication.find(params[:id])
+    @pet_application = PetApplication.find(params[:pet_application_id])
     if @pet_application.update(pet_application_params)
       redirect_to "/admin/applications/#{@application.id}"
     else

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -4,14 +4,12 @@ class ApplicationsController < ApplicationController
     @pets = Pet.search(params[:pet_name]) if params[:pet_name]
   end
 
-  def new
-    # @application = Application.new
-  end
+  def new; end
 
   def create
     @application = Application.new({ name: params[:name], address: params[:address],
-                                      city: params[:city], state: params[:state], zip: params[:zip],
-                                      description: params[:description], status: 'In Progress' })
+                                     city: params[:city], state: params[:state], zip: params[:zip],
+                                     description: params[:description], status: 'In Progress' })
     if @application.save
       redirect_to "/applications/#{@application.id}"
     else

--- a/app/models/pet_application.rb
+++ b/app/models/pet_application.rb
@@ -1,4 +1,8 @@
 class PetApplication < ApplicationRecord
   belongs_to :application
   belongs_to :pet
+
+  def self.by_application_id(application_id)
+    where(:id == application_id)
+  end
 end

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -7,8 +7,13 @@
 <br>Application Status: <%= @application.status %></p>
 
 <% if @application.pets.count > 0 %>
-<br><h2>All Pets:</h2> <% @application.pets.each do |pet| %>
-  <h3> <%= pet.name %> </h3>
-  <p> <%= button_to "Reject #{pet.name}", "/admin/applications/#{@application.id}?status=Rejected", method: :update %> </p>
+  <br><h2>All Pets:</h2>
+  <% @application.pets.each do |pet| %>
+    <h3><%= pet.name %></h3>
+    <% if binding.pry != 'Rejected' %>
+      <%= button_to "Reject #{pet.name}", "/admin/applications/#{@application.id}?status='Rejected'", method: :patch %>
+    <% else %>
+      <p>Rejected</p>
     <% end %>
+  <% end %>
 <% end %>

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -6,8 +6,7 @@
 <% end %>
 <br>Application Status: <%= @application.status %></p>
 
-<% if @application.pets.count > 0 && @application.status == "In Progress"%>
-
+<% if @application.pets.count > 0 %>
 <br><h2>All Pets:</h2> <% @application.pets.each do |pet| %>
   <h3> <%= pet.name %> </h3>
   <p> <%= button_to "Reject #{pet.name}", "/admin/applications/#{@application.id}?status=Rejected", method: :update %> </p>

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -8,12 +8,13 @@
 
 <% if @application.pets.count > 0 %>
   <br><h2>All Pets: </h2>
-  <% @pet_applications.each do |pet_app| %>
+  <% @application.pet_applications.each do |pet_app| %>
     <%= pet_app.pet.name %>
     <% if pet_app.status == "Pending" %>
       <%= button_to "Reject", "/admin/applications/#{@application.id}?status=Rejected", method: :patch, params: {pet_application_id: pet_app.id} %>
       <%= button_to "Approve", "/admin/applications/#{@application.id}?status=Approved", method: :patch, params: {pet_application_id: pet_app.id} %>
+    <% else %>
+      <p><%= pet_app.status.to_s %></p>
     <% end %>
-  <p><%= pet_app.status.to_s %></p>
   <% end %>
 <% end %>

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -10,8 +10,8 @@
   <br><h2>All Pets:</h2>
   <% @application.pets.each do |pet| %>
     <h3><%= pet.name %></h3>
-    <% if binding.pry != 'Rejected' %>
-      <%= button_to "Reject #{pet.name}", "/admin/applications/#{@application.id}?status='Rejected'", method: :patch %>
+    <% if pet.pet_applications[0].status != 'Rejected' %>
+      <%= button_to "Reject", "/admin/applications/#{@application.id}?status='Rejected'", method: :patch,params: {pet_application_id: pet.pet_applications[0].id} %>
     <% else %>
       <p>Rejected</p>
     <% end %>

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -7,13 +7,13 @@
 <br>Application Status: <%= @application.status %></p>
 
 <% if @application.pets.count > 0 %>
-  <br><h2>All Pets:</h2>
-  <% @application.pets.each do |pet| %>
-    <h3><%= pet.name %></h3>
-    <% if pet.pet_applications[0].status != 'Rejected' %>
-      <%= button_to "Reject", "/admin/applications/#{@application.id}?status='Rejected'", method: :patch,params: {pet_application_id: pet.pet_applications[0].id} %>
-    <% else %>
-      <p>Rejected</p>
+  <br><h2>All Pets: </h2>
+  <% @pet_applications.each do |pet_app| %>
+    <%= pet_app.pet.name %>
+    <% if pet_app.status == "Pending" %>
+      <%= button_to "Reject", "/admin/applications/#{@application.id}?status=Rejected", method: :patch, params: {pet_application_id: pet_app.id} %>
+      <%= button_to "Approve", "/admin/applications/#{@application.id}?status=Approved", method: :patch, params: {pet_application_id: pet_app.id} %>
     <% end %>
+  <p><%= pet_app.status.to_s %></p>
   <% end %>
 <% end %>

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -1,0 +1,15 @@
+<p>Name: <%= @application.name %>
+<br>Full Address: <%= @application.address %>, <%= @application.city %>, <%= @application.state %> <%= @application.zip %>
+<br>Description: <%= @application.description %>
+<br>All Pets: <% @application.pets.each do |pet| %>
+  <%= pet.name %>
+<% end %>
+<br>Application Status: <%= @application.status %></p>
+
+<% if @application.pets.count > 0 && @application.status == "In Progress"%>
+
+<br><h2>All Pets:</h2> <% @application.pets.each do |pet| %>
+  <h3> <%= pet.name %> </h3>
+  <p> <%= button_to "Reject #{pet.name}", "/admin/applications/#{@application.id}?status=Rejected", method: :update %> </p>
+    <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   get '/', to: 'application#welcome'
 
   get '/admin/shelters', to: 'admin/shelters#index'
+  patch '/admin/applications/:id', to: 'admin/applications#update'
+  get '/admin/applications/:id', to: 'admin/applications#show'
 
   get '/applications/new', to: 'applications#new'
   get '/applications/:id', to: 'applications#show'

--- a/db/migrate/20240522034351_add_status_to_pet_applications.rb
+++ b/db/migrate/20240522034351_add_status_to_pet_applications.rb
@@ -1,0 +1,5 @@
+class AddStatusToPetApplications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :pet_applications, :status, :string
+  end
+end

--- a/db/migrate/20240522034351_add_status_to_pet_applications.rb
+++ b/db/migrate/20240522034351_add_status_to_pet_applications.rb
@@ -1,5 +1,5 @@
 class AddStatusToPetApplications < ActiveRecord::Migration[7.1]
   def change
-    add_column :pet_applications, :status, :string
+    add_column :pet_applications, :status, :string, default: :Pending, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_22_034351) do
     t.bigint "application_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "status"
+    t.string "status", default: "Pending", null: false
     t.index ["application_id"], name: "index_pet_applications_on_application_id"
     t.index ["pet_id"], name: "index_pet_applications_on_pet_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_16_224505) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_22_034351) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,6 +31,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_16_224505) do
     t.bigint "application_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status"
     t.index ["application_id"], name: "index_pet_applications_on_application_id"
     t.index ["pet_id"], name: "index_pet_applications_on_pet_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,6 +32,6 @@ application2 = Application.create!(name: 'Jane Smith', address: '456 Maple Ave',
                                    zip: '12321', description: 'Interested in a cat', status: 'Approved')
 
 # Pet Applications
-PetApplication.create!(pet: pet1, application: application1, status: 'pending')
-PetApplication.create!(pet: pet2, application: application2, status: 'pending')
-PetApplication.create!(pet: pet3, application: application1, status: 'pending')
+PetApplication.create!(pet: pet1, application: application1, status: :Pending)
+PetApplication.create!(pet: pet2, application: application2, status: :Pending)
+PetApplication.create!(pet: pet3, application: application1, status: :Pending)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,29 +7,31 @@
 #   Character.create(name: "Luke", movie: movies.first)
 
 # Shelters
-shelter1 = Shelter.create!(foster_program: true, name: "Whimsy Whiskers", city: "Denver", rank: 42)
-shelter2 = Shelter.create!(foster_program: false, name: "Sandy Meows", city: "Miami", rank: 42)
-shelter3 = Shelter.create!(foster_program: true, name: "Meow Wows", city: "New York", rank: 42)
+shelter1 = Shelter.create!(foster_program: true, name: 'Whimsy Whiskers', city: 'Denver', rank: 42)
+shelter2 = Shelter.create!(foster_program: false, name: 'Sandy Meows', city: 'Miami', rank: 42)
+shelter3 = Shelter.create!(foster_program: true, name: 'Meow Wows', city: 'New York', rank: 42)
 
 # Pets
-pet1 = Pet.create!(name: "Buddy", breed: "Golden Retriever", age: 3, adoptable: true, shelter: shelter1)
-pet2 = Pet.create!(name: "Mittens", breed: "Tabby", age: 5, adoptable: false, shelter: shelter2)
-pet3 = Pet.create!(name: "Rex", breed: "German Shepherd", age: 2, adoptable: true, shelter: shelter1)
+pet1 = Pet.create!(name: 'Buddy', breed: 'Golden Retriever', age: 3, adoptable: true, shelter: shelter1)
+pet2 = Pet.create!(name: 'Mittens', breed: 'Tabby', age: 5, adoptable: false, shelter: shelter2)
+pet3 = Pet.create!(name: 'Rex', breed: 'German Shepherd', age: 2, adoptable: true, shelter: shelter1)
 
 # Veterinary Offices
-vet_office1 = VeterinaryOffice.create!(name: "Healthy Paws", max_patient_capacity: 50, boarding_services: true)
-vet_office2 = VeterinaryOffice.create!(name: "Animal Care Clinic", max_patient_capacity: 30, boarding_services: false)
+vet_office1 = VeterinaryOffice.create!(name: 'Healthy Paws', max_patient_capacity: 50, boarding_services: true)
+vet_office2 = VeterinaryOffice.create!(name: 'Animal Care Clinic', max_patient_capacity: 30, boarding_services: false)
 
 # Veterinarians
-vet1 = Veterinarian.create!(name: "Dr. Smith", review_rating: 5, on_call: true, veterinary_office: vet_office1)
-vet2 = Veterinarian.create!(name: "Dr. Jones", review_rating: 4, on_call: false, veterinary_office: vet_office2)
-vet3 = Veterinarian.create!(name: "Dr. Brown", review_rating: 3, on_call: true, veterinary_office: vet_office1)
+vet1 = Veterinarian.create!(name: 'Dr. Smith', review_rating: 5, on_call: true, veterinary_office: vet_office1)
+vet2 = Veterinarian.create!(name: 'Dr. Jones', review_rating: 4, on_call: false, veterinary_office: vet_office2)
+vet3 = Veterinarian.create!(name: 'Dr. Brown', review_rating: 3, on_call: true, veterinary_office: vet_office1)
 
 # Applications
-application1 = Application.create!(name: "John Doe", address: "123 Elm St", city: "Miami", state: "FL", zip: "89494", description: "Looking for a friendly dog", status: "Pending")
-application2 = Application.create!(name: "Jane Smith", address: "456 Maple Ave", city: "Denver", state: "CO", zip: "12321", description: "Interested in a cat", status: "Approved")
+application1 = Application.create!(name: 'John Doe', address: '123 Elm St', city: 'Miami', state: 'FL', zip: '89494',
+                                   description: 'Looking for a friendly dog', status: 'Pending')
+application2 = Application.create!(name: 'Jane Smith', address: '456 Maple Ave', city: 'Denver', state: 'CO',
+                                   zip: '12321', description: 'Interested in a cat', status: 'Approved')
 
 # Pet Applications
-PetApplication.create!(pet: pet1, application: application1)
-PetApplication.create!(pet: pet2, application: application2)
-PetApplication.create!(pet: pet3, application: application1)
+PetApplication.create!(pet: pet1, application: application1, status: 'pending')
+PetApplication.create!(pet: pet2, application: application2, status: 'pending')
+PetApplication.create!(pet: pet3, application: application1, status: 'pending')

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'application show' do
     @pet1 = @shelter1.pets.create!(name: 'Buddy', breed: 'Golden Retriever', age: 3, adoptable: true)
     @application1 = Application.create!(name: 'John Doe', address: '123 Elm St', city: 'Denver', state: 'CO',
                                         zip: '12345', description: 'Looking for a friendly dog', status: 'In Progress')
-    PetApplication.create!(pet: @pet1, application: @application1)
+    PetApplication.create!(pet: @pet1, application: @application1, status: 'Pending')
   end
 
   describe 'as a visitor' do
@@ -19,8 +19,9 @@ RSpec.describe 'application show' do
     it 'when a pet is rejected from an application there is a status of rejected and button to reject is gone' do
       visit "/admin/applications/#{@application1.id}"
       expect(page).to_not have_content('Rejected')
-      click_button "Reject #{@pet1.name}"
 
+      click_button "Reject #{@pet1.name}"
+      save_and_open
       expect(page).to have_content('Rejected')
     end
   end

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -41,6 +41,3 @@ RSpec.describe 'application show' do
     end
   end
 end
-# Then I'm taken back to the admin application show page
-# And next to the pet that I rejected, I do not see a button to approve or reject this pet
-# And instead I see an indicator next to the pet that they have been rejected

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'application show' do
 
   describe 'as a visitor' do
     it 'there is a button to reject an application' do
-      visit "/admin/applications/#{@application1}"
+      visit "/admin/applications/#{@application1.id}"
 
       expect(page).to have_content('Reject Application')
     end

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -6,13 +6,14 @@ RSpec.describe 'application show' do
     @pet1 = @shelter1.pets.create!(name: 'Buddy', breed: 'Golden Retriever', age: 3, adoptable: true)
     @application1 = Application.create!(name: 'John Doe', address: '123 Elm St', city: 'Denver', state: 'CO',
                                         zip: '12345', description: 'Looking for a friendly dog', status: 'In Progress')
+    PetApplication.create!(pet: @pet1, application: @application1)
   end
 
   describe 'as a visitor' do
     it 'there is a button to reject an application' do
       visit "/admin/applications/#{@application1.id}"
-
-      expect(page).to have_content('Reject Application')
+      save_and_open_page
+      expect(page).to have_content("Reject #{@pet1.name}")
     end
   end
 end

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'application show' do
+  before do
+    @shelter1 = Shelter.create!(foster_program: true, name: 'Whimsy Whiskers', city: 'Denver', rank: 42)
+    @pet1 = @shelter1.pets.create!(name: 'Buddy', breed: 'Golden Retriever', age: 3, adoptable: true)
+    @application1 = Application.create!(name: 'John Doe', address: '123 Elm St', city: 'Denver', state: 'CO',
+                                        zip: '12345', description: 'Looking for a friendly dog', status: 'In Progress')
+  end
+
+  describe 'as a visitor' do
+    it 'there is a button to reject an application' do
+      visit "/admin/applications/#{@application1}"
+
+      expect(page).to have_content('Reject Application')
+    end
+  end
+end
+# As a visitor
+# When I visit an admin application show page ('/admin/applications/:id')
+# For every pet that the application is for, I see a button to reject the application for that specific pet
+# When I click that button
+# Then I'm taken back to the admin application show page
+# And next to the pet that I rejected, I do not see a button to approve or reject this pet
+# And instead I see an indicator next to the pet that they have been rejected

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe 'application show' do
       visit "/admin/applications/#{@application1.id}"
       expect(page).to_not have_content('Rejected')
 
-      click_button "Reject #{@pet1.name}"
-      save_and_open
+      click_button 'Reject'
+      save_and_open_page
       expect(page).to have_content('Rejected')
     end
   end

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe 'application show' do
 
       expect(page).to have_content("Reject #{@pet1.name}")
     end
+
+    it 'when a pet is rejected from an application there is a status of rejected and button to reject is gone' do
+      visit "/admin/applications/#{@application1.id}"
+      expect(page).to_not have_content('Rejected')
+      click_button "Reject #{@pet1.name}"
+
+      expect(page).to have_content('Rejected')
+    end
   end
 end
 # As a visitor

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'application show' do
   describe 'as a visitor' do
     it 'there is a button to reject an application' do
       visit "/admin/applications/#{@application1.id}"
-      save_and_open_page
+
       expect(page).to have_content("Reject #{@pet1.name}")
     end
   end

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -6,30 +6,41 @@ RSpec.describe 'application show' do
     @pet1 = @shelter1.pets.create!(name: 'Buddy', breed: 'Golden Retriever', age: 3, adoptable: true)
     @application1 = Application.create!(name: 'John Doe', address: '123 Elm St', city: 'Denver', state: 'CO',
                                         zip: '12345', description: 'Looking for a friendly dog', status: 'In Progress')
-    PetApplication.create!(pet: @pet1, application: @application1, status: 'Pending')
+    PetApplication.create!(pet: @pet1, application: @application1, status: :Pending)
   end
 
   describe 'as a visitor' do
     it 'there is a button to reject an application' do
       visit "/admin/applications/#{@application1.id}"
 
-      expect(page).to have_content("Reject #{@pet1.name}")
+      expect(page).to have_content("Reject")
     end
 
     it 'when a pet is rejected from an application there is a status of rejected and button to reject is gone' do
       visit "/admin/applications/#{@application1.id}"
+      
       expect(page).to_not have_content('Rejected')
-
       click_button 'Reject'
-      save_and_open_page
+      
       expect(page).to have_content('Rejected')
+    end
+
+    it 'there is a button to approve an application' do
+      visit "/admin/applications/#{@application1.id}"
+
+      expect(page).to have_content("Approve")
+    end
+
+    it 'when a pet is Approved on an application there is a status of Approved and button to Approve is gone' do
+      visit "/admin/applications/#{@application1.id}"
+      
+      expect(page).to_not have_content('Approved')
+      click_button 'Approve'
+      
+      expect(page).to have_content('Approved')
     end
   end
 end
-# As a visitor
-# When I visit an admin application show page ('/admin/applications/:id')
-# For every pet that the application is for, I see a button to reject the application for that specific pet
-# When I click that button
 # Then I'm taken back to the admin application show page
 # And next to the pet that I rejected, I do not see a button to approve or reject this pet
 # And instead I see an indicator next to the pet that they have been rejected

--- a/spec/features/admin/shelters/index_spec.rb
+++ b/spec/features/admin/shelters/index_spec.rb
@@ -2,32 +2,28 @@ require 'rails_helper'
 
 RSpec.describe 'admin shelter index' do
   before(:each) do
-    @shelter1 = Shelter.create!(foster_program: true, name: "Whimsy Whiskers", city: "Denver", rank: 42)
-    @shelter2 = Shelter.create!(foster_program: true, name: "Meow Wows", city: "New York", rank: 42)
-    @shelter3 = Shelter.create!(foster_program: false, name: "Sandy Meows", city: "Miami", rank: 42)
+    @shelter1 = Shelter.create!(foster_program: true, name: 'Whimsy Whiskers', city: 'Denver', rank: 42)
+    @shelter2 = Shelter.create!(foster_program: true, name: 'Meow Wows', city: 'New York', rank: 42)
+    @shelter3 = Shelter.create!(foster_program: false, name: 'Sandy Meows', city: 'Miami', rank: 42)
   end
 
-  # As a visitor
-  # When I visit the admin shelter index ('/admin/shelters')
-  # Then I see all Shelters in the system listed in reverse alphabetical order by name
   describe 'as a visitor' do
     describe 'when I visit the admin shelter index ("/admin/shelters")' do
       it 'then I see all Shelters in the system listed in reverse alphabetical order by name' do
-        visit "/admin/shelters"
+        visit '/admin/shelters'
 
-        within "#shelter-0" do
-          expect(page).to have_content("Whimsy Whiskers")
+        within '#shelter-0' do
+          expect(page).to have_content('Whimsy Whiskers')
         end
 
-        within "#shelter-1" do
-        expect(page).to have_content("Sandy Meows")
+        within '#shelter-1' do
+          expect(page).to have_content('Sandy Meows')
         end
 
-        within "#shelter-2" do
-        expect(page).to have_content("Meow Wows")
+        within '#shelter-2' do
+          expect(page).to have_content('Meow Wows')
         end
       end
     end
   end
-
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -81,10 +81,6 @@ RSpec.describe 'applications show page' do
     end
   end
 
-  # As a visitor
-  # When I visit an application show page
-  # And I search for Pets by name
-  # Then I see any pet whose name PARTIALLY matches my search
   describe 'as a visitor' do
     describe 'when I visit an application show page' do
       describe 'and I search for Pets by name' do
@@ -94,21 +90,16 @@ RSpec.describe 'applications show page' do
           fill_in 'pet_name', with: 'Bud'
           click_button 'Search'
 
-          expect(page).to have_content("Buddy")
+          expect(page).to have_content('Buddy')
         end
 
-        # As a visitor
-        # When I visit an application show page
-        # And I search for Pets by name
-        # Then my search is case insensitive
-        # For example, if I search for "fluff", my search would match pets with names "Fluffy", "FLUFF", and "Mr. FlUfF"
         it 'then my search is case insensitive' do
           visit "/applications/#{@application1.id}"
 
           fill_in 'pet_name', with: 'bud'
           click_button 'Search'
 
-          expect(page).to have_content("Buddy")
+          expect(page).to have_content('Buddy')
         end
 
         it 'then my search is case insensitive' do
@@ -117,7 +108,7 @@ RSpec.describe 'applications show page' do
           fill_in 'pet_name', with: 'bUd'
           click_button 'Search'
 
-          expect(page).to have_content("Buddy")
+          expect(page).to have_content('Buddy')
         end
       end
     end


### PR DESCRIPTION
This pull request adds functionality to approve or reject pets for adoption within the admin application show page. 
- Added routes for the admin application show
- added migration for status, including giving status a default value of pending
- created an admin applications controller
- added logic to update the pet applications status
- updated view to show the status rather than the buttons for acceptance or rejection
- Added feature tests to cover the approval and rejection 